### PR TITLE
Fix pat decryption js file&chiper signature

### DIFF
--- a/youtubeExtractor/src/main/java/at/huber/youtubeExtractor/YouTubeExtractor.java
+++ b/youtubeExtractor/src/main/java/at/huber/youtubeExtractor/YouTubeExtractor.java
@@ -420,7 +420,8 @@ public abstract class YouTubeExtractor extends AsyncTask<String, Void, SparseArr
     private boolean decipherSignature(final SparseArray<String> encSignatures) throws IOException {
         // Assume the functions don't change that much
         if (decipherFunctionName == null || decipherFunctions == null) {
-            String decipherFunctUrl = "https://youtube.com" + decipherJsFileName;
+            //String decipherFunctUrl = "https://youtube.com" + decipherJsFileName;
+            String decipherFunctUrl = "https://www.youtube.com/watch?v=" + decipherJsFileName;
 
             BufferedReader reader = null;
             String javascriptFile;

--- a/youtubeExtractor/src/main/java/at/huber/youtubeExtractor/YouTubeExtractor.java
+++ b/youtubeExtractor/src/main/java/at/huber/youtubeExtractor/YouTubeExtractor.java
@@ -82,6 +82,7 @@ public abstract class YouTubeExtractor extends AsyncTask<String, Void, SparseArr
     private static final Pattern patFunction = Pattern.compile("([{; =])([a-zA-Z$_][a-zA-Z0-9$]{0,2})\\(");
 
     private static final Pattern patDecryptionJsFile = Pattern.compile("\\\\/s\\\\/player\\\\/([^\"]+?)\\.js");
+    private static final Pattern patDecryptionJsFileWithoutSlash = Pattern.compile("/s/player/([^\"]+?).js");
     private static final Pattern patSignatureDecFunction = Pattern.compile("(?:\\b|[^a-zA-Z0-9$])([a-zA-Z0-9$]{2})\\s*=\\s*function\\(\\s*a\\s*\\)\\s*\\{\\s*a\\s*=\\s*a\\.split\\(\\s*\"\"\\s*\\)");
 
     private static final SparseArray<Format> FORMAT_MAP = new SparseArray<>();
@@ -310,6 +311,8 @@ public abstract class YouTubeExtractor extends AsyncTask<String, Void, SparseArr
             encSignatures = new SparseArray<>();
 
             mat = patDecryptionJsFile.matcher(streamMap);
+            if(!mat.find())
+                mat = patDecryptionJsFileWithoutSlash.matcher(streamMap);
             if (mat.find()) {
                 curJsFileName = mat.group(0).replace("\\/", "/");
                 if (decipherJsFileName == null || !decipherJsFileName.equals(curJsFileName)) {
@@ -420,8 +423,7 @@ public abstract class YouTubeExtractor extends AsyncTask<String, Void, SparseArr
     private boolean decipherSignature(final SparseArray<String> encSignatures) throws IOException {
         // Assume the functions don't change that much
         if (decipherFunctionName == null || decipherFunctions == null) {
-            //String decipherFunctUrl = "https://youtube.com" + decipherJsFileName;
-            String decipherFunctUrl = "https://www.youtube.com/watch?v=" + decipherJsFileName;
+            String decipherFunctUrl = "https://youtube.com" + decipherJsFileName;
 
             BufferedReader reader = null;
             String javascriptFile;

--- a/youtubeExtractor/src/main/java/at/huber/youtubeExtractor/YouTubeExtractor.java
+++ b/youtubeExtractor/src/main/java/at/huber/youtubeExtractor/YouTubeExtractor.java
@@ -341,8 +341,11 @@ public abstract class YouTubeExtractor extends AsyncTask<String, Void, SparseArr
                 if (mat2.find()) {
                     url = URLDecoder.decode(mat2.group(1), "UTF-8");
                     mat2 = patEncSig.matcher(cipher);
-                    if (mat2.find()) {
+                    if (mat2.find()) {                        
                         sig = URLDecoder.decode(mat2.group(1), "UTF-8");
+                        // fix issue #165
+                        sig = sig.replace("\\u0026", "&");
+                        sig = sig.split("&")[0];
                     } else {
                         continue;
                     }


### PR DESCRIPTION
Hi @HaarigerHarald,
In the last few days I found a problem with the url of videos with encrypted signature. In practice the url 's/player/....js 'is now returned without slash and consequently the Pattern patDecryptionJsFile failed in matching check.
I also added the fix proposed by @lortspogi [#165](https://github.com/HaarigerHarald/android-youtubeExtractor/issues/165) solves the problem of HTTP ERROR 403 on private videos. 