### PR TITLE
Filter out videos using FORMAT_STREAM_TYPE_OTF

### DIFF
--- a/youtubeExtractor/src/main/java/at/huber/youtubeExtractor/YouTubeExtractor.java
+++ b/youtubeExtractor/src/main/java/at/huber/youtubeExtractor/YouTubeExtractor.java
@@ -231,6 +231,14 @@ public abstract class YouTubeExtractor extends AsyncTask<String, Void, SparseArr
             for (int i = 0; i < formats.length(); i++) {
 
                 JSONObject format = formats.getJSONObject(i);
+
+                // FORMAT_STREAM_TYPE_OTF(otf=1) requires downloading the init fragment (adding
+                // `&sq=0` to the URL) and parsing emsg box to determine the number of fragment that
+                // would subsequently requested with (`&sq=N`) (cf. youtube-dl)
+                String type = format.getString("type");
+                if (type != null && type.equals("FORMAT_STREAM_TYPE_OTF"))
+                    continue;
+
                 int itag = format.getInt("itag");
 
                 if (FORMAT_MAP.get(itag) != null) {
@@ -255,6 +263,11 @@ public abstract class YouTubeExtractor extends AsyncTask<String, Void, SparseArr
             for (int i = 0; i < adaptiveFormats.length(); i++) {
 
                 JSONObject adaptiveFormat = adaptiveFormats.getJSONObject(i);
+
+                String type = adaptiveFormat.getString("type");
+                if (type != null && type.equals("FORMAT_STREAM_TYPE_OTF"))
+                    continue;
+
                 int itag = adaptiveFormat.getInt("itag");
 
                 if (FORMAT_MAP.get(itag) != null) {

--- a/youtubeExtractor/src/main/java/at/huber/youtubeExtractor/YouTubeExtractor.java
+++ b/youtubeExtractor/src/main/java/at/huber/youtubeExtractor/YouTubeExtractor.java
@@ -235,7 +235,7 @@ public abstract class YouTubeExtractor extends AsyncTask<String, Void, SparseArr
                 // FORMAT_STREAM_TYPE_OTF(otf=1) requires downloading the init fragment (adding
                 // `&sq=0` to the URL) and parsing emsg box to determine the number of fragment that
                 // would subsequently requested with (`&sq=N`) (cf. youtube-dl)
-                String type = format.getString("type");
+                String type = format.optString("type");
                 if (type != null && type.equals("FORMAT_STREAM_TYPE_OTF"))
                     continue;
 
@@ -264,7 +264,7 @@ public abstract class YouTubeExtractor extends AsyncTask<String, Void, SparseArr
 
                 JSONObject adaptiveFormat = adaptiveFormats.getJSONObject(i);
 
-                String type = adaptiveFormat.getString("type");
+                String type = adaptiveFormat.optString("type");
                 if (type != null && type.equals("FORMAT_STREAM_TYPE_OTF"))
                     continue;
 


### PR DESCRIPTION
I noticed that all videos that have "type": "FORMAT_STREAM_TYPE_OTF" produce a 404 error when trying to stream the URL. In youtube-dl repository they provide an explanation for this:

https://github.com/ytdl-org/youtube-dl/blob/a8035827177d6b59aca03bd717acb6a9bdd75ada/youtube_dl/extractor/youtube.py#L1620

This fixes the issue by filtering those formats out like they do in youtube-dl.